### PR TITLE
Adds nested forms for offer_items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ group :development, :test do
   gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'webmock', '~> 1.22.1'
 end
 
 group :test do
@@ -86,6 +85,7 @@ group :test do
   gem 'shoulda-matchers', '~> 3.0.1'
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'webmock', '~> 1.22.1'
 end
 
 group :production do

--- a/app/admin/offer.rb
+++ b/app/admin/offer.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register Offer do
   permit_params :deliver_coordinator_id, :bank_account_id, :producer_id, :title, :image, :value, :stock,
                 :description, :offer_ends_at, :operational_tax, :coordinator_tax,
-                :collect_ends_at, :offer_starts_at, :collect_starts_at
+                :collect_ends_at, :offer_starts_at, :collect_starts_at,
+                offer_items_attributes:[:id, :name, :unit, :quantity, :unit_price, :_destroy]
 
   menu priority: 7
 
@@ -56,6 +57,26 @@ ActiveAdmin.register Offer do
       row :collect_ends_at
     end
 
+    panel 'Items da oferta' do
+      table_for offer.offer_items.order(name: :asc) do
+        column :name do |item|
+          item.name
+        end
+        column :unit do |item|
+          OfferItemUnit.t item.unit
+        end
+        column :quantity do |item|
+          item.quantity
+        end
+        column :unit_price do |item|
+          number_to_currency item.unit_price
+        end
+        column :total do |item|
+          number_to_currency item.total
+        end
+      end
+    end
+
     panel 'Compras para esta oferta' do
       table_for offer.purchases.order(status: :desc) do
         column :invoice_id do |purchase|
@@ -89,6 +110,14 @@ ActiveAdmin.register Offer do
       f.input :offer_ends_at
       f.input :collect_starts_at
       f.input :collect_ends_at
+
+      f.has_many :offer_items do |a|
+        a.input :name
+        a.input :unit, as: :select, collection: OfferItemUnit.to_a
+        a.input :quantity
+        a.input :unit_price
+        a.input :_destroy, as: :boolean, label: 'Remover?'
+      end
     end
 
     f.actions

--- a/app/admin/offer.rb
+++ b/app/admin/offer.rb
@@ -111,12 +111,14 @@ ActiveAdmin.register Offer do
       f.input :collect_starts_at
       f.input :collect_ends_at
 
-      f.has_many :offer_items do |a|
-        a.input :name
-        a.input :unit, as: :select, collection: OfferItemUnit.to_a
-        a.input :quantity
-        a.input :unit_price
-        a.input :_destroy, as: :boolean, label: 'Remover?'
+      panel '' do
+        f.has_many :offer_items do |a|
+          a.input :name
+          a.input :unit, as: :select, collection: OfferItemUnit.to_a
+          a.input :quantity
+          a.input :unit_price
+          a.input :_destroy, as: :boolean, label: 'Remover?'
+        end
       end
     end
 

--- a/app/admin/offer.rb
+++ b/app/admin/offer.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Offer do
   permit_params :deliver_coordinator_id, :bank_account_id, :producer_id, :title, :image, :value, :stock,
-                :products_description, :offer_ends_at, :operational_tax, :coordinator_tax,
+                :description, :offer_ends_at, :operational_tax, :coordinator_tax,
                 :collect_ends_at, :offer_starts_at, :collect_starts_at
 
   menu priority: 7
@@ -41,8 +41,8 @@ ActiveAdmin.register Offer do
       row :stock do |offer|
         "Resta #{offer.remaining} de #{offer.stock}"
       end
-      row :products_description do |offer|
-        simple_format offer.products_description
+      row :description do |offer|
+        simple_format offer.description
       end
       row :operational_tax do |offer|
         number_to_currency offer.operational_tax
@@ -84,7 +84,7 @@ ActiveAdmin.register Offer do
       f.input :operational_tax
       f.input :coordinator_tax
       f.input :stock
-      f.input :products_description, as: :html_editor
+      f.input :description, as: :html_editor
       f.input :offer_starts_at
       f.input :offer_ends_at
       f.input :collect_starts_at

--- a/app/assets/stylesheets/organisms/_offer-info.scss
+++ b/app/assets/stylesheets/organisms/_offer-info.scss
@@ -79,13 +79,15 @@
 .offer-info__collect,
 .offer-info__products { margin-bottom: 60px; }
 
-.offer-info__tax {
+.offer-info__tax,
+.offer-info__products {
   table {
     background-color: $brown-light;
     tr {
       border-bottom: 1px solid $brown-medium;
       &:last-child { border-bottom: 0px; }
-      td {
+      td,
+      th {
         padding: 15px 20px;
         border-top: 0px;
       }

--- a/app/enumerations/offer_item_unit.rb
+++ b/app/enumerations/offer_item_unit.rb
@@ -1,0 +1,7 @@
+class OfferItemUnit < EnumerateIt::Base
+  associate_values kg: 'kg',
+                   bottle: 'bottle',
+                   pack: 'pack',
+                   stem: 'stem',
+                   head: 'head'
+end

--- a/app/mailers/remembers.rb
+++ b/app/mailers/remembers.rb
@@ -34,6 +34,7 @@ class Remembers < ApplicationMailer
   def buyer(user, offer)
     @user = user
     @offer = offer
+    @purchase = offer.purchases.includes(:orders).find_by(user: @user)
     @day = Date.today
     mail to: user.email, subject: "Lembrete de coleta Tribo Viva"
   end

--- a/app/mailers/remembers.rb
+++ b/app/mailers/remembers.rb
@@ -22,6 +22,7 @@ class Remembers < ApplicationMailer
     @offer = offer
     @deliver_coordinator = offer.deliver_coordinator
     @purchases = @offer.purchases.by_status(PurchaseStatus::PAID).includes(:orders)
+    @quotes_quantity = @purchases.includes(:orders).where(orders: {offer: @offer}).sum('orders.quantity')
     @day = Date.today
     mail to: @deliver_coordinator.email, subject: "Lembrete de entrega Tribo Viva"
   end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -7,9 +7,12 @@ class Offer < ActiveRecord::Base
   has_many :old_purchases
   has_many :orders
   has_many :purchases, through: :orders
+  has_many :offer_items, dependent: :destroy
+
+  accepts_nested_attributes_for :offer_items, allow_destroy: true, reject_if: :all_blank
 
   validates :deliver_coordinator, :bank_account, :producer, :title, :image, :value, :stock,
-            :products_description, :offer_ends_at, :operational_tax, :coordinator_tax,
+            :description, :offer_ends_at, :operational_tax, :coordinator_tax,
             :collect_ends_at, :offer_starts_at, :collect_starts_at, presence: true
 
   mount_uploader :image, OfferUploader

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -6,7 +6,7 @@ class Offer < ActiveRecord::Base
   belongs_to :deliver_coordinator
   has_many :old_purchases
   has_many :orders
-  has_many :purchases, through: :orders
+  has_many :purchases, -> { by_status(PurchaseStatus::PAID) }, through: :orders
   has_many :offer_items, dependent: :destroy
 
   accepts_nested_attributes_for :offer_items, allow_destroy: true, reject_if: :all_blank

--- a/app/models/offer_item.rb
+++ b/app/models/offer_item.rb
@@ -1,0 +1,9 @@
+class OfferItem < ActiveRecord::Base
+  belongs_to :offer
+
+  validates :name, :unit, :offer, :quantity, :unit_price, presence: true
+
+  def total
+    unit_price * quantity
+  end
+end

--- a/app/models/offer_item.rb
+++ b/app/models/offer_item.rb
@@ -1,7 +1,7 @@
 class OfferItem < ActiveRecord::Base
   belongs_to :offer
 
-  validates :name, :unit, :offer, :quantity, :unit_price, presence: true
+  validates :name, :unit, :quantity, :unit_price, presence: true
 
   def total
     unit_price * quantity

--- a/app/views/checkouts/success.html.slim
+++ b/app/views/checkouts/success.html.slim
@@ -14,6 +14,25 @@ section.purchase
             - @purchase.orders.each do |order|
               h3.title--up.text--green = order.offer.title
               .offer-info__products  
+                - if order.offer.offer_items.any?
+                .table-responsive
+                  table.table.table-bordered
+                    tr
+                      th.text--green Nome
+                      th.text--green Quantidade
+                      th.text--green Preço Un.
+                      th.text--green Total
+                    - order.offer.offer_items.each do |item|
+                      tr
+                        td = item.name
+                        td 
+                          span 
+                            | #{item.quantity} #{OfferItemUnit.t item.unit}
+                        td = number_to_currency item.unit_price
+                        td = number_to_currency item.total
+
+                p = simple_format order.offer.description
+                br
                 ul 
                   li QUANTIDADE: #{order.quantity} cota(s)
                   li VALOR UNITÁRIO (repassados ao produtor): #{number_to_currency order.offer.value}
@@ -24,25 +43,6 @@ section.purchase
                     | #{t('activerecord.attributes.offer.coordinator_tax')}: 
                     |  #{number_to_currency order.offer.coordinator_tax}
                   li TOTAL DA OFERTA: #{number_to_currency order.total}
-                .row
-                  - if order.offer.offer_items.any?
-                    table.table.table-striped
-                      tr
-                        th Nome
-                        th Quantidade
-                        th Unidade
-                        th Preço Unitário
-                        th Preço Total
-                      - order.offer.offer_items.each do |item|
-                        tr
-                          td = item.name
-                          td = item.quantity
-                          td = OfferItemUnit.t item.unit
-                          td = number_to_currency item.unit_price
-                          td = number_to_currency item.total
-                
-                .row
-                  p = simple_format order.offer.description
 
               .offer-info__collect
                 .offer-info__coordinator

--- a/app/views/checkouts/success.html.slim
+++ b/app/views/checkouts/success.html.slim
@@ -24,7 +24,7 @@ section.purchase
                     | #{t('activerecord.attributes.offer.coordinator_tax')}: 
                     |  #{number_to_currency order.offer.coordinator_tax}
                   li TOTAL DA OFERTA: #{number_to_currency order.total}
-                p = simple_format order.offer.products_description                
+                p = simple_format order.offer.description                
               .offer-info__collect
                 .offer-info__coordinator
                   span.offer-info__coordinator__avatar style="background-image: url(#{order.offer.deliver_coordinator.avatar});"
@@ -82,7 +82,7 @@ section.purchase
                     | #{t('activerecord.attributes.offer.coordinator_tax')}: 
                     |  #{number_to_currency order.offer.coordinator_tax}
                   li TOTAL DA OFERTA: #{number_to_currency order.total}
-                p = simple_format order.offer.products_description                
+                p = simple_format order.offer.description                
               
             span.text--green VALOR DA TRANSAÇÃO: #{number_to_currency @purchase.taxes}
             h2.title--up.text--green.u-marginTop5 TOTAL A PAGAR: #{number_to_currency @purchase.total_with_taxes}.

--- a/app/views/checkouts/success.html.slim
+++ b/app/views/checkouts/success.html.slim
@@ -24,7 +24,26 @@ section.purchase
                     | #{t('activerecord.attributes.offer.coordinator_tax')}: 
                     |  #{number_to_currency order.offer.coordinator_tax}
                   li TOTAL DA OFERTA: #{number_to_currency order.total}
-                p = simple_format order.offer.description                
+                .row
+                  - if order.offer.offer_items.any?
+                    table.table.table-striped
+                      tr
+                        th Nome
+                        th Quantidade
+                        th Unidade
+                        th Preço Unitário
+                        th Preço Total
+                      - order.offer.offer_items.each do |item|
+                        tr
+                          td = item.name
+                          td = item.quantity
+                          td = OfferItemUnit.t item.unit
+                          td = number_to_currency item.unit_price
+                          td = number_to_currency item.total
+                
+                .row
+                  p = simple_format order.offer.description
+
               .offer-info__collect
                 .offer-info__coordinator
                   span.offer-info__coordinator__avatar style="background-image: url(#{order.offer.deliver_coordinator.avatar});"
@@ -82,7 +101,25 @@ section.purchase
                     | #{t('activerecord.attributes.offer.coordinator_tax')}: 
                     |  #{number_to_currency order.offer.coordinator_tax}
                   li TOTAL DA OFERTA: #{number_to_currency order.total}
-                p = simple_format order.offer.description                
+                .row
+                  - if order.offer.offer_items.any?
+                    table.table.table-striped
+                      tr
+                        th Nome
+                        th Quantidade
+                        th Unidade
+                        th Preço Unitário
+                        th Preço Total
+                      - order.offer.offer_items.each do |item|
+                        tr
+                          td = item.name
+                          td = item.quantity
+                          td = OfferItemUnit.t item.unit
+                          td = number_to_currency item.unit_price
+                          td = number_to_currency item.total
+                
+                .row
+                  p = simple_format order.offer.description                
               
             span.text--green VALOR DA TRANSAÇÃO: #{number_to_currency @purchase.taxes}
             h2.title--up.text--green.u-marginTop5 TOTAL A PAGAR: #{number_to_currency @purchase.total_with_taxes}.

--- a/app/views/offers/new_purchase.html.slim
+++ b/app/views/offers/new_purchase.html.slim
@@ -10,7 +10,26 @@ section.purchase
               span.glyphicon.glyphicon-grain
               = @offer.producer.name
             .offer-info__products
-              p = simple_format @offer.description
+              .row
+                - if @offer.offer_items.any?
+                  table.table.table-striped
+                    tr
+                      th Nome
+                      th Quantidade
+                      th Unidade
+                      th Preço Unitário
+                      th Preço Total
+                    - @offer.offer_items.each do |item|
+                      tr
+                        td = item.name
+                        td = item.quantity
+                        td = OfferItemUnit.t item.unit
+                        td = number_to_currency item.unit_price
+                        td = number_to_currency item.total
+              
+              .row
+                p = simple_format @offer.description
+            
             .offer-info__collect
               h3.title--up.text--green Sobre a coleta
               .offer-info__coordinator

--- a/app/views/offers/new_purchase.html.slim
+++ b/app/views/offers/new_purchase.html.slim
@@ -10,7 +10,7 @@ section.purchase
               span.glyphicon.glyphicon-grain
               = @offer.producer.name
             .offer-info__products
-              p = simple_format @offer.products_description
+              p = simple_format @offer.description
             .offer-info__collect
               h3.title--up.text--green Sobre a coleta
               .offer-info__coordinator

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -36,25 +36,23 @@ section.offer-info
           .col-sm-6.col-md-8
             .offer-info__products
               h2.title--up.text--green O que vem na oferta
-              .row
-                - if @offer.offer_items.any?
-                  table.table.table-striped
+              - if @offer.offer_items.any?
+                table.table.table-brown-light
+                  .table-responsive
                     tr
-                      th Nome
-                      th Quantidade
-                      th Unidade
-                      th Preço Unitário
-                      th Preço Total
+                      th.text--green Nome
+                      th.text--green Quantidade
+                      th.text--green Preço Un.
+                      th.text--green Total
                     - @offer.offer_items.each do |item|
                       tr
                         td = item.name
-                        td = item.quantity
-                        td = OfferItemUnit.t item.unit
+                        td 
+                          span 
+                            | #{item.quantity} #{OfferItemUnit.t item.unit}
                         td = number_to_currency item.unit_price
                         td = number_to_currency item.total
-              
-              .row
-                p = simple_format @offer.description
+              p = simple_format @offer.description
             
             .offer-info__collect
               h2.title--up.text--green Sobre a coleta
@@ -99,6 +97,6 @@ section.offer-info
             .offer-info__widget
               .offer-info__widget__info
                 .widget__info__producer
-                  .widget__producer__logo style="background-image: url(#{@offer.producer.logo.url(:thumb)});"
+                  .widget__producer__logo.img-responsive style="background-image: url(#{@offer.producer.logo.url(:thumb)});"
                   h4.widget__producer__name.text--yellow = @offer.producer.name
                 p = simple_format @offer.producer.description

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -1,4 +1,4 @@
-- meta og: { title: "Tribo Viva - #{@offer.title}", description: "#{strip_tags @offer.products_description}",
+- meta og: { title: "Tribo Viva - #{@offer.title}", description: "#{strip_tags @offer.description}",
              url: request.url, image: @offer.image.url }
 
 section.offer-header

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -36,7 +36,26 @@ section.offer-info
           .col-sm-6.col-md-8
             .offer-info__products
               h2.title--up.text--green O que vem na oferta
-              p = simple_format @offer.products_description
+              .row
+                - if @offer.offer_items.any?
+                  table.table.table-striped
+                    tr
+                      th Nome
+                      th Quantidade
+                      th Unidade
+                      th Preço Unitário
+                      th Preço Total
+                    - @offer.offer_items.each do |item|
+                      tr
+                        td = item.name
+                        td = item.quantity
+                        td = OfferItemUnit.t item.unit
+                        td = number_to_currency item.unit_price
+                        td = number_to_currency item.total
+              
+              .row
+                p = simple_format @offer.description
+            
             .offer-info__collect
               h2.title--up.text--green Sobre a coleta
               .offer-info__coordinator

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -37,8 +37,8 @@ section.offer-info
             .offer-info__products
               h2.title--up.text--green O que vem na oferta
               - if @offer.offer_items.any?
-                table.table.table-brown-light
-                  .table-responsive
+                .table-responsive
+                  table.table.table-brown-light
                     tr
                       th.text--green Nome
                       th.text--green Quantidade
@@ -72,25 +72,26 @@ section.offer-info
                   p.hint.text--brown__medium Por motivos de segurança, o número do endereço só será fornecido para os participantes da oferta.
             .offer-info__tax
               h2.title--up.text--green Taxas operacionais
-              table.table.table-brown-light
-                tbody
-                  tr
-                    td.width-80
-                      strong.text--green VALOR DA COTA (repassados ao produtor)
-                    td.text-right
-                      = number_to_currency @offer.value
-                  - if @offer.operational_tax.present?
+              .table-responsive
+                table.table.table-brown-light
+                  tbody
                     tr
                       td.width-80
-                        strong.text--green = t('activerecord.attributes.offer.operational_tax')
+                        strong.text--green VALOR DA COTA (repassados ao produtor)
                       td.text-right
-                        = number_to_currency @offer.operational_tax
-                  - if @offer.coordinator_tax.present?
-                    tr
-                      td.width-80
-                        strong.text--green = t('activerecord.attributes.offer.coordinator_tax')
-                      td.text-right
-                        = number_to_currency @offer.coordinator_tax
+                        = number_to_currency @offer.value
+                    - if @offer.operational_tax.present?
+                      tr
+                        td.width-80
+                          strong.text--green = t('activerecord.attributes.offer.operational_tax')
+                        td.text-right
+                          = number_to_currency @offer.operational_tax
+                    - if @offer.coordinator_tax.present?
+                      tr
+                        td.width-80
+                          strong.text--green = t('activerecord.attributes.offer.coordinator_tax')
+                        td.text-right
+                          = number_to_currency @offer.coordinator_tax
 
           .col-sm-6.col-md-4
             h2.title--up.text--green Sobre o Produtor

--- a/app/views/remembers/buyer.html.slim
+++ b/app/views/remembers/buyer.html.slim
@@ -8,9 +8,26 @@ p
 h2 ITENS DA COLETA
 
 p
-  | Os ALIMENTOS a serem coletados por você são:
+  | Os ALIMENTOS a serem coletados por você são (<b>para cada cota comprada</b>):
   br
   br
+
+- if @offer.offer_items.any?
+  table.table.table-striped
+    tr
+      th Nome
+      th Quantidade
+      th Unidade
+      th Preço Unitário
+      th Preço Total
+    - @offer.offer_items.each do |item|
+      tr
+        td = item.name
+        td = item.quantity
+        td = OfferItemUnit.t item.unit
+        td = number_to_currency item.unit_price
+        td = number_to_currency item.total
+
 == simple_format @offer.description
 
 h2 LOCAL, HORÁRIO, COORDENADOR

--- a/app/views/remembers/buyer.html.slim
+++ b/app/views/remembers/buyer.html.slim
@@ -11,7 +11,7 @@ p
   | Os ALIMENTOS a serem coletados por você são:
   br
   br
-== simple_format @offer.products_description
+== simple_format @offer.description
 
 h2 LOCAL, HORÁRIO, COORDENADOR
 p ENDEREÇO: #{@offer.deliver_coordinator.address}

--- a/app/views/remembers/buyer.html.slim
+++ b/app/views/remembers/buyer.html.slim
@@ -8,7 +8,7 @@ p
 h2 ITENS DA COLETA
 
 p
-  | Os ALIMENTOS a serem coletados por você são (<b>para cada cota comprada</b>):
+  | Os ALIMENTOS a serem coletados por você são:
   br
   br
 
@@ -18,15 +18,11 @@ p
       th Nome
       th Quantidade
       th Unidade
-      th Preço Unitário
-      th Preço Total
     - @offer.offer_items.each do |item|
       tr
         td = item.name
-        td = item.quantity
+        td = item.quantity*@purchase.orders.sum(:quantity)
         td = OfferItemUnit.t item.unit
-        td = number_to_currency item.unit_price
-        td = number_to_currency item.total
 
 == simple_format @offer.description
 

--- a/app/views/remembers/buyer.text.erb
+++ b/app/views/remembers/buyer.text.erb
@@ -12,7 +12,7 @@ Os ALIMENTOS a serem coletados por você são:
 
 <% if @offer.offer_items.any? %>
   <% @offer.offer_items.each do |item| %>
-    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+    Nome: <%= item.name %>, Quantidade: <%= item.quantity*@purchase.orders.sum(:quantity) %>
   <% end %>
 <% end %>
 

--- a/app/views/remembers/buyer.text.erb
+++ b/app/views/remembers/buyer.text.erb
@@ -8,7 +8,7 @@ ITENS DA COLETA
 
 Os ALIMENTOS a serem coletados por você são:
 
-<%= ActionController::Base.helpers.strip_tags @offer.products_description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
+<%= ActionController::Base.helpers.strip_tags @offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 
 LOCAL, HORÁRIO, COORDENADOR
 ENDEREÇO: <%= @offer.deliver_coordinator.address %>

--- a/app/views/remembers/buyer.text.erb
+++ b/app/views/remembers/buyer.text.erb
@@ -10,6 +10,12 @@ Os ALIMENTOS a serem coletados por você são:
 
 <%= ActionController::Base.helpers.strip_tags @offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 
+<% if @offer.offer_items.any? %>
+  <% @offer.offer_items.each do |item| %>
+    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+  <% end %>
+<% end %>
+
 LOCAL, HORÁRIO, COORDENADOR
 ENDEREÇO: <%= @offer.deliver_coordinator.address %>
 HORÁRIO: <%= @offer.delivery_time_range %>.

--- a/app/views/remembers/deliver_coordinator.html.slim
+++ b/app/views/remembers/deliver_coordinator.html.slim
@@ -13,24 +13,20 @@ p Entregador: #{@offer.producer.contact_name} (Telefone: #{@offer.producer.phone
 p Horário de entrega: #{I18n.l @offer.collect_starts_at - 2.hours, format: :short} (aproximadamente).
 
 p
-  | Produtos de <b>CADA UMA</b> das cotas:
+  | Produtos de todas as cotas:
   br
-  
+
 - if @offer.offer_items.any?
   table.table.table-striped
     tr
       th Nome
       th Quantidade
       th Unidade
-      th Preço Unitário
-      th Preço Total
     - @offer.offer_items.each do |item|
       tr
         td = item.name
-        td = item.quantity
+        td = item.quantity*@quotes_quantity
         td = OfferItemUnit.t item.unit
-        td = number_to_currency item.unit_price
-        td = number_to_currency item.total
 
 == simple_format @offer.description
 
@@ -55,3 +51,7 @@ p
   | A Tribo Viva conta com um parceiro de entregas, caso você necessite de um.
   br
   | Para mais informações, clique #{link_to 'aqui', delivery_url}.
+
+h2 Dúvidas?
+
+p Qualquer dúvida ... ligue para gente: Pietro Rocha (51) 9856 1431 ou Marcos Delgado (51) 92056715

--- a/app/views/remembers/deliver_coordinator.html.slim
+++ b/app/views/remembers/deliver_coordinator.html.slim
@@ -13,8 +13,25 @@ p Entregador: #{@offer.producer.contact_name} (Telefone: #{@offer.producer.phone
 p Horário de entrega: #{I18n.l @offer.collect_starts_at - 2.hours, format: :short} (aproximadamente).
 
 p
-  | Produtos:
+  | Produtos de <b>CADA UMA</b> das cotas:
   br
+  
+- if @offer.offer_items.any?
+  table.table.table-striped
+    tr
+      th Nome
+      th Quantidade
+      th Unidade
+      th Preço Unitário
+      th Preço Total
+    - @offer.offer_items.each do |item|
+      tr
+        td = item.name
+        td = item.quantity
+        td = OfferItemUnit.t item.unit
+        td = number_to_currency item.unit_price
+        td = number_to_currency item.total
+
 == simple_format @offer.description
 
 hr

--- a/app/views/remembers/deliver_coordinator.html.slim
+++ b/app/views/remembers/deliver_coordinator.html.slim
@@ -15,7 +15,7 @@ p Horário de entrega: #{I18n.l @offer.collect_starts_at - 2.hours, format: :sho
 p
   | Produtos:
   br
-== simple_format @offer.products_description
+== simple_format @offer.description
 
 hr
 

--- a/app/views/remembers/deliver_coordinator.text.erb
+++ b/app/views/remembers/deliver_coordinator.text.erb
@@ -9,7 +9,7 @@ Entregador: <%= @offer.producer.contact_name %> (Telefone: <%= @offer.producer.p
 Horário de entrega: <%= I18n.l @offer.collect_starts_at - 2.hours, format: :short %> (aproximadamente).
 
 Produtos:
-<%= ActionController::Base.helpers.strip_tags @offer.products_description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
+<%= ActionController::Base.helpers.strip_tags @offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 
 COLETA
 

--- a/app/views/remembers/deliver_coordinator.text.erb
+++ b/app/views/remembers/deliver_coordinator.text.erb
@@ -11,9 +11,10 @@ Horário de entrega: <%= I18n.l @offer.collect_starts_at - 2.hours, format: :sho
 Produtos de CADA UMA das cotas:
 <%= ActionController::Base.helpers.strip_tags @offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 
+- quotes_quantity = @purchases.includes(:orders).where(orders: {offer: @offer}).sum('orders.quantity')
 <% if @offer.offer_items.any? %>
   <% @offer.offer_items.each do |item| %>
-    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+    Nome: <%= item.name %>, Quantidade: <%= item.quantity*quotes_quantity %>
   <% end %>
 <% end %>
 
@@ -32,5 +33,6 @@ PARCEIRO DE ENTREGAS
 A Tribo Viva conta com um parceiro de entregas, caso você necessite de um.
 Para mais informações, visite <%= delivery_url %>.
 
-Atenciosamente,
-Tribo Viva - (51) 9205.6715
+DÚVIDAS?
+
+Qualquer dúvida ... ligue para gente: Pietro Rocha (51) 9856 1431 ou Marcos Delgado (51) 92056715

--- a/app/views/remembers/deliver_coordinator.text.erb
+++ b/app/views/remembers/deliver_coordinator.text.erb
@@ -8,8 +8,14 @@ Entregador: <%= @offer.producer.contact_name %> (Telefone: <%= @offer.producer.p
 
 Horário de entrega: <%= I18n.l @offer.collect_starts_at - 2.hours, format: :short %> (aproximadamente).
 
-Produtos:
+Produtos de CADA UMA das cotas:
 <%= ActionController::Base.helpers.strip_tags @offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
+
+<% if @offer.offer_items.any? %>
+  <% @offer.offer_items.each do |item| %>
+    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+  <% end %>
+<% end %>
 
 COLETA
 

--- a/app/views/remembers/producer.html.slim
+++ b/app/views/remembers/producer.html.slim
@@ -14,22 +14,15 @@ p Seguem as informações sobre as #{@offers.count} entregas de amanhã, #{I18n.
   p Horário: #{I18n.l offer.collect_starts_at - 2.hours, format: :short} (aproximadamente).
 
   h3 Produtos:
-  
   - if offer.offer_items.any?
     table.table.table-striped
       tr
-        th Nome
-        th Quantidade
-        th Unidade
-        th Preço Unitário
-        th Preço Total
+        th Nome do item
+        th Quantidade de itens
       - offer.offer_items.each do |item|
         tr
           td = item.name
-          td = item.quantity
-          td = OfferItemUnit.t item.unit
-          td = number_to_currency item.unit_price
-          td = number_to_currency item.total
+          td = item.quantity*offer.orders.sum(:quantity)
 
   == simple_format offer.description
   p SUBTOTAL = "#{ActionController::Base.helpers.number_to_currency offer.value} x #{offer.orders.sum(:quantity)} = #{ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total)}"

--- a/app/views/remembers/producer.html.slim
+++ b/app/views/remembers/producer.html.slim
@@ -14,6 +14,23 @@ p Seguem as informações sobre as #{@offers.count} entregas de amanhã, #{I18n.
   p Horário: #{I18n.l offer.collect_starts_at - 2.hours, format: :short} (aproximadamente).
 
   h3 Produtos:
+  
+  - if offer.offer_items.any?
+    table.table.table-striped
+      tr
+        th Nome
+        th Quantidade
+        th Unidade
+        th Preço Unitário
+        th Preço Total
+      - offer.offer_items.each do |item|
+        tr
+          td = item.name
+          td = item.quantity
+          td = OfferItemUnit.t item.unit
+          td = number_to_currency item.unit_price
+          td = number_to_currency item.total
+
   == simple_format offer.description
   p SUBTOTAL = "#{ActionController::Base.helpers.number_to_currency offer.value} x #{offer.orders.sum(:quantity)} = #{ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total)}"
 

--- a/app/views/remembers/producer.html.slim
+++ b/app/views/remembers/producer.html.slim
@@ -14,7 +14,7 @@ p Seguem as informações sobre as #{@offers.count} entregas de amanhã, #{I18n.
   p Horário: #{I18n.l offer.collect_starts_at - 2.hours, format: :short} (aproximadamente).
 
   h3 Produtos:
-  == simple_format offer.products_description
+  == simple_format offer.description
   p SUBTOTAL = "#{ActionController::Base.helpers.number_to_currency offer.value} x #{offer.orders.sum(:quantity)} = #{ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total)}"
 
   iframe src="#{'https://maps.google.com/?q='+URI.encode(offer.deliver_coordinator.address)+'&output=embed'}" width="600" height="450" frameborder="0" style="border:0"

--- a/app/views/remembers/producer.text.erb
+++ b/app/views/remembers/producer.text.erb
@@ -15,6 +15,13 @@ Horário: <%= I18n.l offer.collect_starts_at - 2.hours, format: :short %> (aprox
 
 Produtos:
 <%= ActionController::Base.helpers.strip_tags offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
+
+<% if offer.offer_items.any? %>
+  <% offer.offer_items.each do |item| %>
+    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+  <% end %>
+<% end %>
+
 SUBTOTAL: <%= ActionController::Base.helpers.number_to_currency offer.value %> x <%= offer.orders.sum(:quantity) %> = <%= ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total) %>
 
 <% items << offer.purchases.sum(:total) %>

--- a/app/views/remembers/producer.text.erb
+++ b/app/views/remembers/producer.text.erb
@@ -14,7 +14,7 @@ Coordenador de entrega: <%= offer.deliver_coordinator.name %> - <%= offer.delive
 Horário: <%= I18n.l offer.collect_starts_at - 2.hours, format: :short %> (aproximadamente).
 
 Produtos:
-<%= ActionController::Base.helpers.strip_tags offer.products_description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
+<%= ActionController::Base.helpers.strip_tags offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 SUBTOTAL: <%= ActionController::Base.helpers.number_to_currency offer.value %> x <%= offer.orders.sum(:quantity) %> = <%= ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total) %>
 
 <% items << offer.purchases.sum(:total) %>

--- a/app/views/remembers/producer.text.erb
+++ b/app/views/remembers/producer.text.erb
@@ -4,27 +4,27 @@ Seguem as informações sobre as <%= @offers.count %> entregas de amanhã, <%= I
 
 <% items = [] %>
 <% @offers.each_with_index do |offer, index| %>
-====================================
+  ====================================
 
-ENTREGA <%= index + 1 %>
+  ENTREGA <%= index + 1 %>
 
-INFORMAÇÕES
-Endereço: <%= offer.deliver_coordinator.address %>
-Coordenador de entrega: <%= offer.deliver_coordinator.name %> - <%= offer.deliver_coordinator.phone %>
-Horário: <%= I18n.l offer.collect_starts_at - 2.hours, format: :short %> (aproximadamente).
+  INFORMAÇÕES
+  Endereço: <%= offer.deliver_coordinator.address %>
+  Coordenador de entrega: <%= offer.deliver_coordinator.name %> - <%= offer.deliver_coordinator.phone %>
+  Horário: <%= I18n.l offer.collect_starts_at - 2.hours, format: :short %> (aproximadamente).
 
-Produtos:
-<%= ActionController::Base.helpers.strip_tags offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
-
-<% if offer.offer_items.any? %>
-  <% offer.offer_items.each do |item| %>
-    <%= item.name %>, <%= item.quantity %>, <%= OfferItemUnit.t(item.unit) %>, <%= number_to_currency(item.unit_price) %>, <%= number_to_currency(item.total) %>
+  Produtos:
+  <% if offer.offer_items.any? %>
+    <% offer.offer_items.each do |item| %>
+      Nome: <%= item.name %>, Quantidade: <%= item.quantity*offer.orders.sum(:quantity) %>
+    <% end %>
   <% end %>
-<% end %>
 
-SUBTOTAL: <%= ActionController::Base.helpers.number_to_currency offer.value %> x <%= offer.orders.sum(:quantity) %> = <%= ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total) %>
+  <%= ActionController::Base.helpers.strip_tags offer.description.gsub(/<\/(p|li|ul|br)>/, "\n") %>
 
-<% items << offer.purchases.sum(:total) %>
+  SUBTOTAL: <%= ActionController::Base.helpers.number_to_currency offer.value %> x <%= offer.orders.sum(:quantity) %> = <%= ActionController::Base.helpers.number_to_currency offer.purchases.sum(:total) %>
+
+  <% items << offer.purchases.sum(:total) %>
 <% end %>
 
 ==================

--- a/config/locales/offer.pt-BR.yml
+++ b/config/locales/offer.pt-BR.yml
@@ -12,6 +12,7 @@ pt-BR:
         title: 'Nome da oferta'
         image: 'Imagem da oferta'
         producer: 'Produtor'
+        description: 'Descrição'
         bank_account: 'Conta bancária'
         offer_ends_at: 'Oferta encerra em'
         operational_tax: 'TAXA OPERACIONAL (sustentabilidade da Rede)'
@@ -20,4 +21,3 @@ pt-BR:
         collect_ends_at: 'Coleta termina em'
         collect_starts_at: 'Coleta inicia em'
         deliver_coordinator: 'Coordenador de entrega'
-        products_description: 'Descrição dos produtos'

--- a/config/locales/offer_item.pt-BR.yml
+++ b/config/locales/offer_item.pt-BR.yml
@@ -1,0 +1,22 @@
+pt-BR:
+  activerecord:
+    models:
+      offer_item:
+        one: 'Item'
+        other: 'Items'
+
+    attributes:
+      offer_item:
+        name: 'Nome'
+        unit: 'Unidade'
+        offer: 'Oferta'
+        quantity: 'Quantidade'
+        unit_price: 'Preço unitário'
+
+  enumerations:
+    offer_item_unit:
+      kg: 'Kg'
+      bottle: 'Garrafa'
+      pack: 'Maço'
+      stem: 'Pé'
+      head: 'Cabeça'

--- a/db/migrate/20151028221934_create_offer_items.rb
+++ b/db/migrate/20151028221934_create_offer_items.rb
@@ -1,0 +1,13 @@
+class CreateOfferItems < ActiveRecord::Migration
+  def change
+    create_table :offer_items do |t|
+      t.references :offer, index: true, foreign_key: true
+      t.string :name, nul: false, default: ''
+      t.string :unit, null: false, default: 1
+      t.integer :quantity, null: false, default: 1
+      t.decimal :unit_price, null: false, default: 0.0, scale: 2, precision: 10
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151028223047_rename_products_description_to_description_on_offers.rb
+++ b/db/migrate/20151028223047_rename_products_description_to_description_on_offers.rb
@@ -1,0 +1,5 @@
+class RenameProductsDescriptionToDescriptionOnOffers < ActiveRecord::Migration
+  def change
+    rename_column :offers, :products_description, :description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027003206) do
+ActiveRecord::Schema.define(version: 20151028223047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,11 +73,23 @@ ActiveRecord::Schema.define(version: 20151027003206) do
     t.string   "partial_address", default: "",  null: false
   end
 
+  create_table "offer_items", force: :cascade do |t|
+    t.integer  "offer_id"
+    t.string   "name",                                default: ""
+    t.string   "unit",                                default: "1", null: false
+    t.integer  "quantity",                            default: 1,   null: false
+    t.decimal  "unit_price", precision: 10, scale: 2, default: 0.0, null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+  end
+
+  add_index "offer_items", ["offer_id"], name: "index_offer_items_on_offer_id", using: :btree
+
   create_table "offers", force: :cascade do |t|
     t.integer  "deliver_coordinator_id"
     t.integer  "bank_account_id"
     t.integer  "producer_id"
-    t.text     "products_description",                            default: "",  null: false
+    t.text     "description",                                     default: "",  null: false
     t.string   "title",                                           default: "",  null: false
     t.string   "image",                                           default: "",  null: false
     t.decimal  "value",                  precision: 10, scale: 2, default: 0.0, null: false
@@ -173,6 +185,7 @@ ActiveRecord::Schema.define(version: 20151027003206) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "offer_items", "offers"
   add_foreign_key "offers", "bank_accounts"
   add_foreign_key "offers", "deliver_coordinators"
   add_foreign_key "offers", "producers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,13 +53,23 @@ if Rails.env.development? || Rails.env.staging?
                  image: File.open('spec/support/example.jpg'),
                  value: 49.90,
                  stock: 10,
-                 products_description: "Lorem ipsum Velit minim laboris sint pariatur reprehenderit veniam do quis qui anim ad irure laborum in sint ad est ex id ad ex commodo Duis aliquip aliqua et reprehenderit sed ut culpa laboris culpa ex do ex labore nulla cillum.",
+                 description: "Lorem ipsum Velit minim laboris sint pariatur reprehenderit veniam do quis qui anim ad irure laborum in sint ad est ex id ad ex commodo Duis aliquip aliqua et reprehenderit sed ut culpa laboris culpa ex do ex labore nulla cillum.",
                  operational_tax: 4.99,
                  coordinator_tax: 4.99,
                  offer_starts_at: 1.day.from_now,
                  offer_ends_at: 9.day.from_now,
                  collect_starts_at: 10.day.from_now,
                  collect_ends_at: 20.days.from_now)
+
+    10.times do |item|
+      OfferItem.create!(
+      name: "Item de nome #{item}",
+      unit: OfferItemUnit.to_a.sample,
+      offer: Offer.last,
+      quantity: item,
+      unit_price: 5+item
+      )
+    end
 
     5.times do |index2|
       user  = User.find(index2+1)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,38 +19,38 @@ if Rails.env.development? || Rails.env.staging?
   printf "====== Creating Producers & Deliver Coordinators ... "
 
   10.times do |index|
-    Producer.create(name: "Produtor #{index}",
+    Producer.create!(name: "Produtor #{index}",
                     phone: "321321321",
                     email: "email_do_produtor_#{index}@test.com",
                     address: "Rua do Produtor #{index}",
                     description: "Lorem ipsum Et incididunt culpa ad esse adipisicing anim sed ex minim exercitation sint magna sunt aliquip culpa ad velit dolore officia magna dolore eu id dolore Ut nostrud ut Ut sint id occaecat consectetur cillum ut culpa est dolore exercitation nostrud in laboris do ut id cupidatat et fugiat in et ex sunt tempor nisi Duis eu esse ad ut ex enim non aute in eu eu amet est aliqua veniam exercitation in sed eiusmod aliquip non aliqua sunt Excepteur labore et qui amet laboris aute esse voluptate veniam irure cillum consectetur sed enim officia ea nisi Excepteur non Ut irure incididunt adipisicing ullamco ut aute elit officia fugiat Duis mollit velit reprehenderit sint et do voluptate Ut proident incididunt in minim reprehenderit magna non et anim aliquip eiusmod ullamco ut velit reprehenderit magna nostrud sint dolor in sit in Duis ullamco esse ea eiusmod non in Duis sint aliquip commodo dolor sed est in magna anim eu Duis dolore labore voluptate aliquip velit veniam non incididunt deserunt Ut commodo deserunt ex commodo et id sunt sint ut veniam commodo deserunt tempor occaecat occaecat aute ea id qui qui eiusmod nisi ex est pariatur veniam occaecat aute deserunt sint esse magna nulla Excepteur sit in ex.",
                     contact_name: "Contato Produtor #{index}",
-                    remote_logo_url: 'http://theoldreader.com/kittens/200/200/')
+                    logo: File.open('spec/support/example.jpg'))
 
-    DeliverCoordinator.create(name: "Coordenador #{index}",
+    DeliverCoordinator.create!(name: "Coordenador #{index}",
                               phone: "321321321",
                               email: "email_do_coordenador_#{index}@test.com",
                               address: "Rua do coordenador #{index}",
                               partial_address: "Rua do coordenador",
                               cpf: "00914969000",
-                              remote_avatar_url: 'http://theoldreader.com/kittens/200/200/')
+                              avatar: File.open('spec/support/example.jpg'))
   end
 
   printf "DONE! ======\n\n"
   printf "====== Creating Example Bank Accounts ... "
 
-  BankAccount.create(cc: '01014278-0', bank: 'Santander', agency: '1208', bank_number: '001',
+  BankAccount.create!(cc: '01014278-0', bank: 'Santander', agency: '1208', bank_number: '001',
                      operation_code: '002', owner_name: 'John Doe', cnpj_cpf: '000000000000')
 
   printf "DONE! ======\n\n"
   printf "====== Creating Example Offers ... "
 
   3.times do |index|
-    Offer.create(deliver_coordinator: DeliverCoordinator.last,
+    Offer.create!(deliver_coordinator: DeliverCoordinator.last,
                  bank_account: BankAccount.last,
                  producer: Producer.last,
                  title: "Oferta Nº #{index+1}",
-                 remote_image_url: 'http://theoldreader.com/kittens/200/200/',
+                 image: File.open('spec/support/example.jpg'),
                  value: 49.90,
                  stock: 10,
                  products_description: "Lorem ipsum Velit minim laboris sint pariatur reprehenderit veniam do quis qui anim ad irure laborum in sint ad est ex id ad ex commodo Duis aliquip aliqua et reprehenderit sed ut culpa laboris culpa ex do ex labore nulla cillum.",
@@ -64,10 +64,10 @@ if Rails.env.development? || Rails.env.staging?
     5.times do |index2|
       user  = User.find(index2+1)
       offer = Offer.last
-      OldPurchase.create(user: user, offer: offer, amount: 1, status: OldPurchaseStatus::CONFIRMED,
+      OldPurchase.create!(user: user, offer: offer, amount: 1, status: OldPurchaseStatus::CONFIRMED,
                       receipt: File.open('spec/support/example.jpg'))
-      Purchase.create(user: user, status: 'paid', total: 0)
-      Order.create(offer: offer, purchase: Purchase.last, offer_value: offer.value, quantity: 3)
+      Purchase.create!(user: user, status: 'paid', total: 0, invoice_id: index2.to_s+"32UH13I21H312IU")
+      Order.create!(offer: offer, purchase: Purchase.last, offer_value: offer.value, quantity: 3)
     end
   end
 

--- a/spec/models/offer_item_spec.rb
+++ b/spec/models/offer_item_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe OfferItem, type: :model do
   describe "validations" do
     it { should validate_presence_of :name }
     it { should validate_presence_of :unit }
-    it { should validate_presence_of :offer }
     it { should validate_presence_of :quantity }
     it { should validate_presence_of :unit_price }
   end

--- a/spec/models/offer_item_spec.rb
+++ b/spec/models/offer_item_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe OfferItem, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :unit }
+    it { should validate_presence_of :offer }
+    it { should validate_presence_of :quantity }
+    it { should validate_presence_of :unit_price }
+  end
+
+  describe "relations" do
+    it { should belong_to :offer }
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Offer, type: :model do
     it { should validate_presence_of :value }
     it { should validate_presence_of :stock }
     it { should validate_presence_of :producer }
+    it { should validate_presence_of :description }
     it { should validate_presence_of :bank_account }
     it { should validate_presence_of :offer_ends_at }
     it { should validate_presence_of :operational_tax }
@@ -15,12 +16,12 @@ RSpec.describe Offer, type: :model do
     it { should validate_presence_of :offer_starts_at }
     it { should validate_presence_of :collect_starts_at }
     it { should validate_presence_of :deliver_coordinator }
-    it { should validate_presence_of :products_description }
   end
 
   describe "relations" do
     it { should have_many :orders }
     it { should belong_to :producer }
+    it { should have_many :offer_items }
     it { should belong_to :bank_account }
     it { should have_many :old_purchases }
     it { should belong_to :deliver_coordinator }

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -55,7 +55,7 @@ Offer.blueprint do
   image { File.open('spec/support/example.jpg') }
   value { 49.90 }
   stock { 10 }
-  products_description { "Lorem ipsum." }
+  description { "Lorem ipsum." }
   operational_tax { 4.99 }
   coordinator_tax { 4.99 }
   offer_starts_at { 1.day.from_now }


### PR DESCRIPTION
## For what

This way now instead of filling a description field with the itens, you can add various items to some offer
## Images
### Mailers
#### Coordinator

![screen shot 2015-10-28 at 22 19 45](https://cloud.githubusercontent.com/assets/1644530/10807111/3e1f4490-7dc3-11e5-881b-5539055127ce.png)
#### Buyer

![screen shot 2015-10-28 at 22 20 39](https://cloud.githubusercontent.com/assets/1644530/10807109/3e11a2fe-7dc3-11e5-8007-6ebc277da257.png)
### Front pages
#### checkout#success

![screen shot 2015-10-28 at 22 21 36](https://cloud.githubusercontent.com/assets/1644530/10807110/3e18eb0e-7dc3-11e5-9dd4-f57e0c021225.png)
#### offer#show

![screen shot 2015-10-28 at 22 21 55](https://cloud.githubusercontent.com/assets/1644530/10807112/3e2770ac-7dc3-11e5-8a59-5e0ee01eb7ff.png)
